### PR TITLE
fix: resolve dropdown and dashboard typing

### DIFF
--- a/src/components/FamilyFeedCard.tsx
+++ b/src/components/FamilyFeedCard.tsx
@@ -4,6 +4,7 @@ import { colors, radius, spacing, theme } from "../theme";
 import { Card } from "./Card";
 import { Badge } from "./Badge";
 import { FeedItem } from "../store/feedStore";
+import { formatRelativeTime, getAuthorName } from "../lib/feedUtils";
 
 interface FamilyFeedCardProps {
   item: FeedItem;
@@ -20,16 +21,6 @@ export const FamilyFeedCard: React.FC<FamilyFeedCardProps> = ({
   onPress,
   currentUserId,
 }) => {
-  // Map author IDs to display names
-  const getAuthorName = (authorId: string) => {
-    const authorNames: Record<string, string> = {
-      "skarlette-choi": "Skarlette Choi",
-      nurse1: "Nurse Smith",
-      nurse2: "Nurse Johnson",
-    };
-    return authorNames[authorId] || authorId;
-  };
-
   // Get update type configuration for family-friendly display
   const getUpdateConfig = (type: string) => {
     const configs: Record<
@@ -127,30 +118,6 @@ export const FamilyFeedCard: React.FC<FamilyFeedCardProps> = ({
     return configs[type] || configs.note;
   };
 
-  // Format timestamp in a family-friendly way
-  const formatTimestamp = (timestamp: string) => {
-    const date = new Date(timestamp);
-    const now = new Date();
-    const diffInHours = Math.floor(
-      (now.getTime() - date.getTime()) / (1000 * 60 * 60)
-    );
-
-    if (diffInHours < 1) {
-      return "Just now";
-    } else if (diffInHours < 2) {
-      return "1 hour ago";
-    } else if (diffInHours < 24) {
-      return `${diffInHours} hours ago`;
-    } else {
-      const diffInDays = Math.floor(diffInHours / 24);
-      if (diffInDays === 1) {
-        return "Yesterday";
-      } else {
-        return `${diffInDays} days ago`;
-      }
-    }
-  };
-
   const config = getUpdateConfig(item.type);
   const reactions = item.reactions || { heart: 0, reactedByMe: false };
   const authorName = getAuthorName(item.authorId);
@@ -187,7 +154,7 @@ export const FamilyFeedCard: React.FC<FamilyFeedCardProps> = ({
           </View>
           <View style={styles.timeContainer}>
             <Text style={styles.timestamp}>
-              {formatTimestamp(item.createdAt)}
+              {formatRelativeTime(item.createdAt, "friendly")}
             </Text>
           </View>
         </View>

--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -4,6 +4,7 @@ import { colors, radius, spacing, theme } from "../theme";
 import { Card } from "./Card";
 import { Badge } from "./Badge";
 import { FeedItem } from "../store/feedStore";
+import { formatRelativeTime, getAuthorName } from "../lib/feedUtils";
 
 interface FeedCardProps {
   item: FeedItem;
@@ -22,33 +23,6 @@ export const FeedCard: React.FC<FeedCardProps> = ({
   showAuthorBadge = false,
   currentUserId,
 }) => {
-  // Map author IDs to display names
-  const getAuthorName = (authorId: string) => {
-    const authorNames: Record<string, string> = {
-      "skarlette-choi": "Skarlette Choi",
-      nurse1: "Nurse Smith",
-      nurse2: "Nurse Johnson",
-    };
-    return authorNames[authorId] || authorId;
-  };
-
-  // Format timestamp
-  const formatTimestamp = (timestamp: string) => {
-    const date = new Date(timestamp);
-    const now = new Date();
-    const diffInHours = Math.floor(
-      (now.getTime() - date.getTime()) / (1000 * 60 * 60)
-    );
-
-    if (diffInHours < 1) {
-      return "Just now";
-    } else if (diffInHours < 24) {
-      return `${diffInHours}h ago`;
-    } else {
-      const diffInDays = Math.floor(diffInHours / 24);
-      return `${diffInDays}d ago`;
-    }
-  };
 
   const handleReaction = () => {
     onToggleReaction(item.id);
@@ -103,7 +77,7 @@ export const FeedCard: React.FC<FeedCardProps> = ({
             )}
           </View>
           <Text style={styles.timestamp}>
-            {formatTimestamp(item.createdAt)}
+            {formatRelativeTime(item.createdAt)}
           </Text>
         </View>
 

--- a/src/components/QuickAddDropdown.tsx
+++ b/src/components/QuickAddDropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from "react";
+import type { ComponentRef } from "react";
 import {
   View,
   Text,
@@ -104,11 +105,16 @@ export const QuickAddDropdown: React.FC<QuickAddDropdownProps> = ({
     width: number;
     height: number;
   } | null>(null);
-  const buttonRef = useRef<TouchableOpacity>(null);
+  const buttonRef = useRef<ComponentRef<typeof TouchableOpacity> | null>(null);
 
   const handleButtonPress = () => {
     if (buttonRef.current) {
-      buttonRef.current.measureInWindow((x, y, width, height) => {
+      buttonRef.current.measureInWindow((
+        x: number,
+        y: number,
+        width: number,
+        height: number
+      ) => {
         setButtonLayout({ x, y, width, height });
         setIsVisible(true);
       });

--- a/src/lib/feedUtils.ts
+++ b/src/lib/feedUtils.ts
@@ -1,0 +1,44 @@
+const AUTHOR_NAME_MAP: Record<string, string> = {
+  "skarlette-choi": "Skarlette Choi",
+  nurse1: "Nurse Smith",
+  nurse2: "Nurse Johnson",
+};
+
+type RelativeTimeVariant = "compact" | "friendly";
+
+export const getAuthorName = (authorId: string) => {
+  return AUTHOR_NAME_MAP[authorId] ?? authorId;
+};
+
+export const formatRelativeTime = (
+  timestamp: string,
+  variant: RelativeTimeVariant = "compact"
+) => {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffInHours = Math.floor(
+    (now.getTime() - date.getTime()) / (1000 * 60 * 60)
+  );
+
+  if (diffInHours < 1) {
+    return "Just now";
+  }
+
+  if (diffInHours < 24) {
+    if (variant === "friendly") {
+      return diffInHours === 1
+        ? "1 hour ago"
+        : `${diffInHours} hours ago`;
+    }
+
+    return `${diffInHours}h ago`;
+  }
+
+  const diffInDays = Math.floor(diffInHours / 24);
+
+  if (variant === "friendly") {
+    return diffInDays === 1 ? "Yesterday" : `${diffInDays} days ago`;
+  }
+
+  return `${diffInDays}d ago`;
+};

--- a/src/screens/staff/StaffDashboardScreen.tsx
+++ b/src/screens/staff/StaffDashboardScreen.tsx
@@ -16,21 +16,12 @@ import { ResidentStatusCard } from "../../components/ResidentStatusCard";
 import { CategoryRecents } from "../../components/CategoryRecents";
 import { IconDisplay } from "../../components/IconDisplay";
 import { useFeedStore } from "../../store/feedStore";
+import { getAuthorName } from "../../lib/feedUtils";
 
 export const StaffDashboardScreen: React.FC = () => {
   const navigation = useNavigation();
   const { getTodayStats, setActiveResident, feed, residents } = useFeedStore();
   const contentContainerStyle = useContentContainerStyle();
-
-  // Map author IDs to display names
-  const getAuthorName = (authorId: string) => {
-    const authorNames: Record<string, string> = {
-      "skarlette-choi": "Skarlette Choi",
-      nurse1: "Nurse Smith",
-      nurse2: "Nurse Johnson",
-    };
-    return authorNames[authorId] || authorId;
-  };
 
   // Get real-time stats every time the component renders
   const stats = getTodayStats();

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -33,6 +33,8 @@ export const colors = {
   warningSoft: "#FFFBEB",
   error: "#EF4444",
   errorSoft: "#FEF2F2",
+  info: "#2563EB",
+  infoSoft: "#EFF6FF",
 
   // Status-specific accent bars
   statusActive: "#10B981",
@@ -47,6 +49,7 @@ export const colors = {
 };
 
 export const radius = {
+  xs: 6,
   sm: 8,
   md: 12,
   lg: 16,
@@ -140,6 +143,18 @@ export const theme = {
       lineHeight: 24,
       letterSpacing: -0.2,
     },
+    h2: {
+      fontSize: 24,
+      fontWeight: "700",
+      lineHeight: 30,
+      letterSpacing: -0.3,
+    },
+    h3: {
+      fontSize: 18,
+      fontWeight: "700",
+      lineHeight: 22,
+      letterSpacing: -0.15,
+    },
     sectionTitle: {
       fontSize: 18,
       fontWeight: "700",
@@ -152,6 +167,11 @@ export const theme = {
       fontSize: 16,
       fontWeight: "400",
       lineHeight: 22,
+    },
+    bodyLarge: {
+      fontSize: 17,
+      fontWeight: "500",
+      lineHeight: 24,
     },
     bodyMedium: {
       fontSize: 16,


### PR DESCRIPTION
## Summary
- type the quick add dropdown ref and measurement callback to satisfy TypeScript
- extend the theme with the info palette, small radius, and heading/body tokens used by the care dashboard

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d4b08e39848331816fbca0aad42624